### PR TITLE
feat: add support for macOS Ventura (13.x)

### DIFF
--- a/internal/system/product.go
+++ b/internal/system/product.go
@@ -15,6 +15,7 @@ const (
 	Catalina
 	BigSur
 	Monterey
+	Ventura
 	CompatMode
 )
 
@@ -28,6 +29,8 @@ func (r Release) String() string {
 		return "Big Sur"
 	case Monterey:
 		return "Monterey"
+	case Ventura:
+		return "Ventura"
 	case CompatMode:
 		return "Compatability Mode"
 	default:
@@ -44,6 +47,8 @@ var (
 	bigSurConstraints = mustInitConstraint(semver.NewConstraint("~11"))
 	// montereyConstraints are the constraints used to identify Monterey versions (12.x.x).
 	montereyConstraints = mustInitConstraint(semver.NewConstraint("~12"))
+	// venturaConstraints are the constraints used to identify Ventura versions (13.x.x).
+	venturaConstraints = mustInitConstraint(semver.NewConstraint("~13"))
 	// compatModeConstraints are the constraints used to identify macOS Big Sur and later. This version is returned
 	// when the system is in compat mode (SYSTEM_VERSION_COMPAT=1).
 	compatModeConstraints = mustInitConstraint(semver.NewConstraint("~10.16"))
@@ -96,6 +101,8 @@ func getVersionRelease(version semver.Version) Release {
 		return BigSur
 	case montereyConstraints.Check(&version):
 		return Monterey
+	case venturaConstraints.Check(&version):
+		return Ventura
 	case compatModeConstraints.Check(&version):
 		return CompatMode
 	default:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add support for macOS Ventura (13.x). This will allow ec2-macos-utils to run on EC2 macOS 13.x AMIs.

*Testing*
Tested locally on a mac1.metal 13.2.1 Ventura instance.

```
sudo ./ec2-macos-utils grow --id disk4
INFO[23 May 23 02:00 GMT] Configuring diskutil for product              product="macOS Ventura 13.2.1"
INFO[23 May 23 02:00 GMT] Attempting to grow container...               device_id=disk4
INFO[23 May 23 02:00 GMT] Checking if device can be APFS resized...     device_id=disk4
INFO[23 May 23 02:00 GMT] Device can be resized                        
INFO[23 May 23 02:00 GMT] Repairing the parent disk...                 
INFO[23 May 23 02:00 GMT] Repairing parent disk...                      parent_id=disk0
INFO[23 May 23 02:00 GMT] Successfully repaired the parent disk        
INFO[23 May 23 02:00 GMT] Fetching amount of free space on device...    device_id=disk4
INFO[23 May 23 02:00 GMT] Resizing container to maximum size...         device_id=disk4 free_space="64 GB"
INFO[23 May 23 02:00 GMT] Fetching updated information for device...    device_id=disk4
INFO[23 May 23 02:00 GMT] Successfully grew device to maximum size      device_id=disk4 total_size="322 GB"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
