### PR TITLE
feat(grow): exit quietly if not enough free space

### DIFF
--- a/internal/cmd/grow_container.go
+++ b/internal/cmd/grow_container.go
@@ -82,6 +82,12 @@ func run(utility diskutil.DiskUtil, args growContainer) error {
 
 	logrus.WithField("device_id", di.DeviceIdentifier).Info("Attempting to grow container...")
 	if err := diskutil.GrowContainer(utility, di); err != nil {
+		// Don't treat FreeSpaceErrors as fatal, instead exit quietly since there's nothing else to do.
+		if errors.As(err, &diskutil.FreeSpaceError{}) {
+			logrus.WithField("id", args.id).Info("Nothing to do without free space, stopping command")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/ec2-macos-utils/issues/5

*Description of changes:*
Previously, ec2-macos-util's grow command would error out with exit status 1 if there wasn't enough free space to grow the specified disk. This wasn't proper behavior since a lack of free space is an expected case and should be handled as such.

This change adds an extra check in the grow command to see if GrowContainer funciton returned a FreeSpaceError and exit quietly if it did. This will cause ec2-macos-utils to log an extra message and return with exit status 0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
