### PR TITLE
Add support for macOS Sequoia (15.x)

### DIFF
--- a/internal/diskutil/diskutil.go
+++ b/internal/diskutil/diskutil.go
@@ -101,6 +101,8 @@ func ForProduct(p *system.Product) (DiskUtil, error) {
 		return newVentura(p.Version)
 	case system.Sonoma:
 		return newSonoma(p.Version)
+	case system.Sequoia:
+		return newSequoia(p.Version)
 	default:
 		return nil, errors.New("unknown release")
 	}
@@ -158,6 +160,16 @@ func newVentura(version semver.Version) (*diskutilMonterey, error) {
 
 // newSonoma configures the DiskUtil for the specified Sonoma version.
 func newSonoma(version semver.Version) (*diskutilSonoma, error) {
+	du := &diskutilSonoma{
+		embeddedDiskutil: &DiskUtilityCmd{},
+		dec:              &PlistDecoder{},
+	}
+
+	return du, nil
+}
+
+// newSequoia configures the DiskUtil for the specified Sequoia version.
+func newSequoia(version semver.Version) (*diskutilSonoma, error) {
 	du := &diskutilSonoma{
 		embeddedDiskutil: &DiskUtilityCmd{},
 		dec:              &PlistDecoder{},

--- a/internal/system/product.go
+++ b/internal/system/product.go
@@ -17,6 +17,7 @@ const (
 	Monterey
 	Ventura
 	Sonoma
+	Sequoia
 	CompatMode
 )
 
@@ -34,6 +35,8 @@ func (r Release) String() string {
 		return "Ventura"
 	case Sonoma:
 		return "Sonoma"
+	case Sequoia:
+		return "Sequoia"
 	case CompatMode:
 		return "Compatability Mode"
 	default:
@@ -54,6 +57,8 @@ var (
 	venturaConstraints = mustInitConstraint(semver.NewConstraint("~13"))
 	// sonomaConstraints are the constraints used to identify Sonoma versions (14.x.x).
 	sonomaConstraints = mustInitConstraint(semver.NewConstraint("~14"))
+	// sequoiaConstraints are the constraints used to identify Sequoia versions (15.x.x).
+	sequoiaConstraints = mustInitConstraint(semver.NewConstraint("~15"))
 	// compatModeConstraints are the constraints used to identify macOS Big Sur and later. This version is returned
 	// when the system is in compat mode (SYSTEM_VERSION_COMPAT=1).
 	compatModeConstraints = mustInitConstraint(semver.NewConstraint("~10.16"))
@@ -110,6 +115,8 @@ func getVersionRelease(version semver.Version) Release {
 		return Ventura
 	case sonomaConstraints.Check(&version):
 		return Sonoma
+	case sequoiaConstraints.Check(&version):
+		return Sequoia
 	case compatModeConstraints.Check(&version):
 		return CompatMode
 	default:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Add Sequoia to the list of macOS versions supported by the `system` package. Also added support for the new version in the `diskutil` implementation by reusing Sonoma's implementation.

The `ec2-macos-utils grow` command was tested with these changes on both EC2 Mac architectures on instances that were upgraded from Sonoma 14.6.1 to Sequoia 15.0. `ec2-macos-utils` was able to successfully grow the root volume size from 100 gb to 250 gb on both instances.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
