### PR TITLE
refactor: fix parser and address lints with enabled checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  buildtest-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+      - name: Fetch deps
+        run: make -f ci/Makefile --include-dir ci ci-deps
+      - name: Do Build
+        run: make -f ci/Makefile --include-dir ci ci-build
+      - name: Run Tests
+        run: make -f ci/Makefile --include-dir ci ci-test
+
+  buildtest-macos:
+    needs: buildtest-linux
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+      - name: Fetch deps
+        run: make -f ci/Makefile --include-dir ci ci-deps
+      - name: Do Build
+        run: make -f ci/Makefile --include-dir ci ci-build
+      - name: Run Tests
+        run: make -f ci/Makefile --include-dir ci ci-test
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: buildtest-linux
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+      - name: Run Linter
+        run: make -f ci/Makefile --include-dir ci ci-lint
+

--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,6 @@ imports: $(GOFILES)
 .PHONY: imports-check
 imports-check:
 	$(GOIMPORTS) -e -l -d .
+
+ci-%:
+	$(MAKE) -f ci/Makefile --include-dir ci $(@)

--- a/ci/Makefile
+++ b/ci/Makefile
@@ -1,0 +1,6 @@
+include go.mk
+
+ci-deps: goget
+ci-build: gobuild
+ci-test: gotest
+ci-lint: golint

--- a/ci/go.mk
+++ b/ci/go.mk
@@ -1,0 +1,18 @@
+GO = go
+GOIMPORTS = goimports $(if $(GOPKGPATH),-local $(GOPKGPATH))
+GOLANGCILINT = golangci-lint
+
+goget:
+	$(GO) get -t ./...
+
+gobuild:
+	$(GO) build $(GO_BUILD_FLAGS) $(V) ./...
+
+gotest:
+	$(GO) test $(GO_TEST_FLAGS) $(V) ./...
+
+goimports gofmt:
+	$(GOIMPORTS) -w .
+
+golint:
+	$(GOLANGCILINT) run

--- a/internal/cmd/grow_container_test.go
+++ b/internal/cmd/grow_container_test.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	mock_diskutil "github.com/aws/ec2-macos-utils/internal/diskutil/mocks"
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 }
 
 func TestRun_WithInfoErr(t *testing.T) {

--- a/internal/contextual/values.go
+++ b/internal/contextual/values.go
@@ -6,8 +6,12 @@ import (
 	"github.com/aws/ec2-macos-utils/internal/system"
 )
 
-// productKey is used to set and retrieve context held values for Product.
-var productKey = struct{}{}
+type contextKey uint
+
+const (
+	// productKey is used to access current Product from context.
+	productKey contextKey = iota + 1
+)
 
 // WithProduct extends the context to provide a Product.
 func WithProduct(ctx context.Context, product *system.Product) context.Context {

--- a/internal/diskutil/diskutil.go
+++ b/internal/diskutil/diskutil.go
@@ -149,8 +149,8 @@ func newMonterey(version semver.Version) (*diskutilMonterey, error) {
 }
 
 // newVentura configures the DiskUtil for the specified Ventura version.
-func newVentura(version semver.Version) (*diskutilMonterey, error) {
-	du := &diskutilMonterey{
+func newVentura(version semver.Version) (*diskutilVentura, error) {
+	du := &diskutilVentura{
 		embeddedDiskutil: &DiskUtilityCmd{},
 		dec:              &PlistDecoder{},
 	}

--- a/internal/diskutil/grow.go
+++ b/internal/diskutil/grow.go
@@ -88,8 +88,8 @@ func canAPFSResize(disk *types.DiskInfo) error {
 	}
 
 	// If the disk has ContainerInfo, check the FilesystemType
-	if (disk.ContainerInfo != types.ContainerInfo{}) {
-		if disk.ContainerInfo.FilesystemType == "apfs" {
+	if containerInfo := disk.ContainerInfo; (containerInfo != types.ContainerInfo{}) {
+		if containerInfo.FilesystemType == "apfs" {
 			return nil
 		}
 	}

--- a/internal/diskutil/grow_test.go
+++ b/internal/diskutil/grow_test.go
@@ -3,7 +3,7 @@ package diskutil
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	mock_diskutil "github.com/aws/ec2-macos-utils/internal/diskutil/mocks"
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 }
 
 func TestGrowContainer_WithoutContainer(t *testing.T) {

--- a/internal/diskutil/types/partitions.go
+++ b/internal/diskutil/types/partitions.go
@@ -39,9 +39,16 @@ func (p *SystemPartitions) AvailableDiskSpace(id string) (uint64, error) {
 	return target.Size - allocated, nil
 }
 
-// APFSPhysicalStoreID represents the physical device usually relating to synthesized virtual devices.
+// APFSPhysicalStoreID represents the physical device usually relating
+// to synthesized virtual devices.
 type APFSPhysicalStoreID struct {
 	DeviceIdentifier string `plist:"DeviceIdentifier"`
+}
+
+func NewAPFSPhysicalStoreID(deviceID string) *APFSPhysicalStoreID {
+	return &APFSPhysicalStoreID{
+		DeviceIdentifier: deviceID,
+	}
 }
 
 // DiskPart represents a subset of information from DiskInfo.

--- a/internal/system/doc.go
+++ b/internal/system/doc.go
@@ -1,0 +1,3 @@
+// Package system provides the functionality necessary for interacting
+// with the macOS system.
+package system

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -1,7 +1,7 @@
-// Package system provides the functionality necessary for interacting with the macOS system.
 package system
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -10,15 +10,19 @@ import (
 )
 
 const (
-	// versionPath is the path on the root filesystem to the SystemVersion plist
+	// versionPath is the path on the root filesystem to the
+	// SystemVersion plist
 	versionPath = "/System/Library/CoreServices/SystemVersion.plist"
 
-	// dotVersionPath is the path to the symlink that directly references versionPath and bypasses the compatibility
-	// mode that was introduced with macOS 11.0.
+	// dotVersionPath is the path to the symlink that directly
+	// references versionPath and bypasses the compatibility mode
+	// that was introduced with macOS 11.0.
 	dotVersionPath = "/System/Library/CoreServices/.SystemVersionPlatform.plist"
 
-	// dotVersionSwitch is the product version number returned by macOS when the system is in compat mode
-	// (SYSTEM_VERSION_COMPAT=1). If this version is returned, dotVersionPath should be read to bypass compat mode.
+	// dotVersionSwitch is the product version number returned by
+	// macOS when the system is in compat mode
+	// (SYSTEM_VERSION_COMPAT=1). If this version is returned,
+	// dotVersionPath should be read to bypass compat mode.
 	dotVersionSwitch = "10.16"
 )
 
@@ -32,7 +36,8 @@ func (sys *System) Product() *Product {
 	return sys.product
 }
 
-// Scan reads the VersionInfo and creates a new System struct from that and the associated Product.
+// Scan reads the VersionInfo and creates a new System struct from
+// that and the associated Product.
 func Scan() (*System, error) {
 	version, err := readVersion()
 	if err != nil {
@@ -67,23 +72,22 @@ func (v *VersionInfo) Product() (*Product, error) {
 	return newProduct(v.ProductVersion)
 }
 
-// decodeVersionInfo attempts to decode the raw data from the reader into a new VersionInfo struct.
-func decodeVersionInfo(reader io.ReadSeeker) (version *VersionInfo, err error) {
-	// Create a reader from the raw data and create a new decoder
-	version = &VersionInfo{}
-	decoder := plist.NewDecoder(reader)
-
+// decodeVersionInfo attempts to decode the raw data from the reader
+// into a new VersionInfo struct.
+func decodeVersionInfo(reader io.ReadSeeker) (*VersionInfo, error) {
 	// Decode the system version plist into the VersionInfo struct
-	err = decoder.Decode(version)
-	if err != nil {
+	var version VersionInfo
+	decoder := plist.NewDecoder(reader)	
+	if err := decoder.Decode(&version); err != nil {
 		return nil, fmt.Errorf("system failed to decode contents of reader: %w", err)
 	}
 
-	return version, nil
+	return &version, nil
 }
 
-// readVersion reads the SystemVersion plist data from disk (versionPath). If "SYSTEM_VERSION_COMPAT" is enabled, it will instead
-// read from dotVersionPath to bypass macOS's compat mode.
+// readVersion reads the SystemVersion plist data from disk
+// (versionPath). If "SYSTEM_VERSION_COMPAT" is enabled, it will
+// instead read from dotVersionPath to bypass macOS's compat mode.
 func readVersion() (*VersionInfo, error) {
 	// Read the version info from the standard file path
 	version, err := readProductVersionFile(versionPath)
@@ -91,7 +95,8 @@ func readVersion() (*VersionInfo, error) {
 		return nil, err
 	}
 
-	// If the returned product version is in compat mode, read the version info from the dot file to bypass compat mode.
+	// If the returned product version is in compat mode, read the
+	// version info from the dot file to bypass compat mode.
 	if version.ProductVersion == dotVersionSwitch {
 		return readProductVersionFile(dotVersionPath)
 	}
@@ -99,20 +104,17 @@ func readVersion() (*VersionInfo, error) {
 	return version, nil
 }
 
-// readProductVersion opens the given file and attempts to decode it as VersionInfo.
+// readProductVersion opens the given file and attempts to decode it
+// as VersionInfo.
 func readProductVersionFile(path string) (*VersionInfo, error) {
-	// Open the SystemVersion.plist file
-	versionFile, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	defer versionFile.Close()
-
-	// Get the VersionInfo from the reader
-	version, err := decodeVersionInfo(versionFile)
+	// Parse loaded plist version data
+	version, err := decodeVersionInfo(bytes.NewReader(data))
 	if err != nil {
 		return nil, err
 	}
-
 	return version, nil
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"os/user"
 	"strconv"
-	"strings"
 	"syscall"
 )
 
@@ -99,70 +98,86 @@ func ExecuteCommandYes(ctx context.Context, c []string, runAsUser string, envVar
 // higher success rate. If that fails, return an error. Any successful case returns the UID and GID as ints.
 func getUIDandGID(username string) (uid int, gid int, err error) {
 	var uidstr, gidstr string
+
 	// Preference is user.Lookup(), if it works
-	u, lookuperr := user.Lookup(username)
-	if lookuperr != nil {
-		// user.Lookup() has failed, second try by checking the DS cache
-		out, cmderr := ExecuteCommand(context.Background(), []string{"dscacheutil", "-q", "user", "-a", "name", username}, "", []string{}, nil)
-		if cmderr != nil {
-			// dscacheutil has failed with an error
-			return 0, 0, fmt.Errorf("error while looking up user %s: \n"+
-				"user.Lookup() error: %s \ndscacheutil error: %s\ndscacheutil Stderr: %s\n",
-				username, lookuperr, cmderr, out.Stderr)
-		}
-		// Check length of Stdout - dscacheutil returns nothing if user is not found
-		if len(out.Stdout) > 0 { // dscacheutil has returned something
-			// Command output from dscacheutil should look like:
-			//   name: ec2-user
-			//   password: ********
-			//   uid: 501
-			//   gid: 20
-			//   dir: /Users/ec2-user
-			//   shell: /bin/bash
-			//   gecos: ec2-user
-			dsSplit := strings.Split(out.Stdout, "\n") // split on newline to separate uid and gid
-			for _, e := range dsSplit {
-				eSplit := strings.Fields(e) // split into fields to separate tag with id
-				// Find UID and GID and set them
-				if strings.HasPrefix(e, "uid") {
-					if len(eSplit) != 2 {
-						// dscacheutil has returned some sort of weird output that can't be split
-						return 0, 0, fmt.Errorf("error while splitting dscacheutil uid output for user %s: %s\n"+
-							"user.Lookup() error: %s \ndscacheutil error: %s\ndscacheutil Stderr: %s\n",
-							username, out.Stdout, lookuperr, cmderr, out.Stderr)
-					}
-					uidstr = eSplit[1]
-				} else if strings.HasPrefix(e, "gid") {
-					if len(eSplit) != 2 {
-						// dscacheutil has returned some sort of weird output that can't be split
-						return 0, 0, fmt.Errorf("error while splitting dscacheutil gid output for user %s: %s\n"+
-							"user.Lookup() error: %s \ndscacheutil error: %s\ndscacheutil Stderr: %s\n",
-							username, out.Stdout, lookuperr, cmderr, out.Stderr)
-					}
-					gidstr = eSplit[1]
-				}
-			}
-		} else {
-			// dscacheutil has returned nothing, user is not found
-			return 0, 0, fmt.Errorf("user %s not found: \n"+
-				"user.Lookup() error: %s \ndscacheutil error: %s\ndscacheutil Stderr: %s\n",
-				username, lookuperr, cmderr, out.Stderr)
-		}
-	} else {
+	u, lookupErr := user.Lookup(username)
+	if lookupErr == nil {
 		// user.Lookup() was successful, use the returned UID/GID
 		uidstr = u.Uid
 		gidstr = u.Gid
+	} else {
+		// user.Lookup() has failed, second try by checking the DS cache
+		out, cmdErr := ExecuteCommand(context.Background(), []string{"dscacheutil", "-q", "user", "-a", "name", username}, "", []string{}, nil)
+		if cmdErr != nil {
+			// dscacheutil has failed with an error
+			return 0, 0, fmt.Errorf("dscacheutil: %w", cmdErr)
+		}
+
+		if len(out.Stdout) == 0 {
+			// dscacheutil returns nothing if user is not found
+			return 0, 0, fmt.Errorf("dscacheutil read user %q: %w", username, cmdErr)
+		} else {
+			// dscacheutil found user, extract the user info by keys
+			dscacheUserInfo := extractDSCacheUtilKeyValues([]byte(out.Stdout), []string{"gid", "uid"})
+			if len(dscacheUserInfo) == 0 {
+				return 0, 0, fmt.Errorf("dscacheutil read user %q: %w", username, cmdErr)
+			}
+			if gid, ok := dscacheUserInfo["gid"]; ok {
+				gidstr = gid
+			}
+			if uid, ok := dscacheUserInfo["uid"]; ok {
+				uidstr = uid
+			}
+		}
 	}
 
-	// Convert UID and GID to int
+	// make sure we actually resolved a user before carrying on
+	if uidstr == "" || gidstr == "" {
+		return 0, 0, fmt.Errorf("user %q: no user info", username)
+	}
+
+	// Parse read UID and GID to integers
 	uid, err = strconv.Atoi(uidstr)
 	if err != nil {
-		return 0, 0, fmt.Errorf("error while converting UID to int: %s\n", err)
+		return 0, 0, fmt.Errorf("parse %q uid: %w", username, err)
 	}
 	gid, err = strconv.Atoi(gidstr)
 	if err != nil {
-		return 0, 0, fmt.Errorf("error while converting GID to int: %s\n", err)
+		return 0, 0, fmt.Errorf("parse %q gid: %w", username, err)
 	}
 
 	return uid, gid, nil
+}
+
+func extractDSCacheUtilKeyValues(text []byte, keys []string) map[string]string {
+	// Command output from dscacheutil should look like:
+	//
+	//   name: ec2-user
+	//   password: ********
+	//   uid: 501
+	//   gid: 20
+	//   dir: /Users/ec2-user
+	//   shell: /bin/bash
+	//   gecos: ec2-user
+	//
+
+	extracted := map[string]string{}
+
+	lines := bytes.Split(text, []byte("\n")) // split on newline to separate uid and gid
+	for _, kvLine := range lines {
+		// kv splits the [key: value] lines into their components
+		kv := bytes.SplitN(kvLine, []byte(": "), 2)
+
+		if len(kv) < 2 {
+			continue
+		}
+
+		for _, key := range keys {
+			if bytes.EqualFold(kv[0], []byte(key)) {
+				extracted[key] = string(kv[1])
+			}
+		}
+	}
+
+	return extracted
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -51,7 +51,7 @@ func ExecuteCommand(ctx context.Context, c []string, runAsUser string, envVars [
 	if runAsUser != "" {
 		uid, gid, err := getUIDandGID(runAsUser)
 		if err != nil {
-			return CommandOutput{Stdout: stdoutb.String(), Stderr: stderrb.String()}, fmt.Errorf("error looking up user: %s\n", err)
+			return CommandOutput{Stdout: stdoutb.String(), Stderr: stderrb.String()}, fmt.Errorf("error looking up user: %w", err)
 		}
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,97 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractDSCacheUtilKeyValues(t *testing.T) {
+	t.Run("typical kv lines", func(t *testing.T) {
+		// verify "normal" text has extracted user info
+		const normativeSample = `
+name: ec2-user
+password: ********
+uid: 501
+gid: 20
+dir: /Users/ec2-user
+shell: /bin/bash
+gecos: ec2-user
+`
+		extracted := extractDSCacheUtilKeyValues([]byte(normativeSample), []string{"uid", "gid", "name"})
+		if len(extracted) != 3 {
+			t.Errorf("got back extracted keys: %+v", extracted)
+		}
+
+		for expectedKey, expectedValue := range map[string]string{
+			"name": "ec2-user",
+			"uid": "501",
+			"gid": "20",
+		} {
+			v, ok := extracted[expectedKey]
+			if !ok {
+				t.Errorf("extracted kv should have key %q", expectedKey)
+			}
+			if !strings.EqualFold(v, expectedValue) {
+				t.Errorf("extracted kv should have key %q with value %+v",
+					expectedKey, expectedValue)
+			}
+		}
+	})
+
+	t.Run("mixed kv lines", func(t *testing.T) {
+		// verify keys with mixed characteristics are
+		// extracted with values intact
+		const mixedSample = `
+# busted line
+-ignored-line-
+foo: bar baz
+qux: test
+neato key: and key value
+with sep: : foo
+x: y
+
+: bad
+`
+		extracted := extractDSCacheUtilKeyValues([]byte(mixedSample),
+			[]string{"qux", "neato key", "with sep"})
+		if len(extracted) != 3 {
+			t.Errorf("got back extracted keys: %+v", extracted)
+		}
+
+		for expectedKey, expectedValue := range map[string]string{
+			"qux": "test",
+			"neato key": "and key value",
+			"with sep": ": foo",
+		} {
+			v, ok := extracted[expectedKey]
+			if !ok {
+				t.Errorf("extracted kv should have key %q", expectedKey)
+			}
+			if !strings.EqualFold(v, expectedValue) {
+				t.Errorf("extracted kv should have key %q with value %q",
+					expectedKey, expectedValue)
+			}
+
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		// verify an "empty" output results in empty extraction
+		const emptyNonZeroSample = `
+
+`
+		extracted := extractDSCacheUtilKeyValues([]byte(emptyNonZeroSample), []string{"qux"})
+		if len(extracted) != 0 {
+			t.Errorf("got back extracted keys: %+v", extracted)
+		}
+
+		const someKey = "qux"		
+		v, ok := extracted[someKey]
+		if ok {
+			t.Errorf("extracted kv should NOT have key %q", someKey)
+		}
+		if v != "" {
+			t.Errorf("extracted kv should NOT have value for key %q", someKey)
+		}
+	})
+}


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

This adds GitHub actions to check changes and includes fixes to address identified lints.

There was an unlikely fallthrough case bug in the `dscacheutil` helper that was remedied at the same time as addressing the adjacent lints. These changes are tested by newly added unit tests to validate the parser.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
