### PR TITLE
feat: add support for macOS Tahoe (26.x)

### DIFF
--- a/internal/diskutil/diskutil.go
+++ b/internal/diskutil/diskutil.go
@@ -103,6 +103,8 @@ func ForProduct(p *system.Product) (DiskUtil, error) {
 		return newSonoma(p.Version)
 	case system.Sequoia:
 		return newSequoia(p.Version)
+	case system.Tahoe:
+		return newTahoe(p.Version)
 	default:
 		return nil, errors.New("unknown release")
 	}
@@ -170,6 +172,16 @@ func newSonoma(version semver.Version) (*diskutilSonoma, error) {
 
 // newSequoia configures the DiskUtil for the specified Sequoia version.
 func newSequoia(version semver.Version) (*diskutilSonoma, error) {
+	du := &diskutilSonoma{
+		embeddedDiskutil: &DiskUtilityCmd{},
+		dec:              &PlistDecoder{},
+	}
+
+	return du, nil
+}
+
+// newTahoe configures the DiskUtil for the specified Tahoe version.
+func newTahoe(version semver.Version) (*diskutilSonoma, error) {
 	du := &diskutilSonoma{
 		embeddedDiskutil: &DiskUtilityCmd{},
 		dec:              &PlistDecoder{},

--- a/internal/system/product.go
+++ b/internal/system/product.go
@@ -18,6 +18,7 @@ const (
 	Ventura
 	Sonoma
 	Sequoia
+	Tahoe
 	CompatMode
 )
 
@@ -37,6 +38,8 @@ func (r Release) String() string {
 		return "Sonoma"
 	case Sequoia:
 		return "Sequoia"
+	case Tahoe:
+		return "Tahoe"
 	case CompatMode:
 		return "Compatability Mode"
 	default:
@@ -59,6 +62,8 @@ var (
 	sonomaConstraints = mustInitConstraint(semver.NewConstraint("~14"))
 	// sequoiaConstraints are the constraints used to identify Sequoia versions (15.x.x).
 	sequoiaConstraints = mustInitConstraint(semver.NewConstraint("~15"))
+	// tahoeConstraints are the constraints used to identify Tahoe versions (26.x.x).
+	tahoeConstraints = mustInitConstraint(semver.NewConstraint("~26"))
 	// compatModeConstraints are the constraints used to identify macOS Big Sur and later. This version is returned
 	// when the system is in compat mode (SYSTEM_VERSION_COMPAT=1).
 	compatModeConstraints = mustInitConstraint(semver.NewConstraint("~10.16"))
@@ -117,6 +122,8 @@ func getVersionRelease(version semver.Version) Release {
 		return Sonoma
 	case sequoiaConstraints.Check(&version):
 		return Sequoia
+	case tahoeConstraints.Check(&version):
+		return Tahoe
 	case compatModeConstraints.Check(&version):
 		return CompatMode
 	default:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add support for macOS Tahoe version 26.x.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
