### PR TITLE
feat: Add system cleanup-state subcommand

### DIFF
--- a/docs/ec2-macos-utils.md
+++ b/docs/ec2-macos-utils.md
@@ -21,5 +21,6 @@ help text and usages that accompany them.
 * [ec2-macos-utils check](ec2-macos-utils_check.md)	 - run various system checks
 * [ec2-macos-utils debug](ec2-macos-utils_debug.md)	 - debug utilities for EC2 macOS instances
 * [ec2-macos-utils grow](ec2-macos-utils_grow.md)	 - resize container to max size
+* [ec2-macos-utils system](ec2-macos-utils_system.md)	 - system provisioning & helper utilities
 * [ec2-macos-utils watchdog](ec2-macos-utils_watchdog.md)	 - monitor system health
 

--- a/docs/ec2-macos-utils_system.md
+++ b/docs/ec2-macos-utils_system.md
@@ -1,0 +1,26 @@
+## ec2-macos-utils system
+
+system provisioning & helper utilities
+
+### Synopsis
+
+System provisioning and management utilities for EC2 Mac instances & image
+building.
+
+### Options
+
+```
+  -h, --help   help for system
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose logging output
+```
+
+### SEE ALSO
+
+* [ec2-macos-utils](ec2-macos-utils.md)	 - utilities for EC2 macOS instances
+* [ec2-macos-utils system cleanup-state](ec2-macos-utils_system_cleanup-state.md)	 - remove OS state for instance imaging
+

--- a/docs/ec2-macos-utils_system_cleanup-state.md
+++ b/docs/ec2-macos-utils_system_cleanup-state.md
@@ -1,0 +1,36 @@
+## ec2-macos-utils system cleanup-state
+
+remove OS state for instance imaging
+
+### Synopsis
+
+removes well-known macOS state from the running system that must not be
+carried into an image (AMI) built from this instance.
+
+This removes cached OS state, such as the network interface configuration
+cache (NetworkInterfaces.plist), required when creating & after provisioning
+derived images from an instance.
+
+This command requires root privileges. Run with sudo if not running as root.
+
+```
+ec2-macos-utils system cleanup-state [flags]
+```
+
+### Options
+
+```
+      --dry-run   run command without mutating changes
+  -h, --help      help for cleanup-state
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose logging output
+```
+
+### SEE ALSO
+
+* [ec2-macos-utils system](ec2-macos-utils_system.md)	 - system provisioning & helper utilities
+

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aws/ec2-macos-utils
 go 1.24.0
 
 require (
+	github.com/BurntSushi/toml v1.4.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/ec2-macos-utils
 go 1.24.0
 
 require (
-	github.com/BurntSushi/toml v1.4.0
+	github.com/BurntSushi/toml v1.6.0
 	github.com/Masterminds/semver v1.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/dustin/go-humanize v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
-github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -24,6 +24,7 @@ func MainCommand() *cobra.Command {
 		growContainerCommand(),
 		checkCommand(),
 		debugCommand(),
+		systemCommand(),
 		watchdogCommand(),
 	}
 	for i := range cmds {

--- a/internal/cmd/system.go
+++ b/internal/cmd/system.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/aws/ec2-macos-utils/internal/system"
+)
+
+func systemCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "system",
+		Short: "system provisioning & helper utilities",
+		Long: strings.TrimSpace(`
+System provisioning and management utilities for EC2 Mac instances & image
+building.
+        `),
+	}
+
+	cmd.AddCommand(cleanupStateCommand())
+
+	return cmd
+}
+
+func cleanupStateCommand() *cobra.Command {
+	var dryRun bool
+
+	cmd := &cobra.Command{
+		Use:   "cleanup-state",
+		Short: "remove OS state for instance imaging",
+		Long: strings.TrimSpace(`
+removes well-known macOS state from the running system that must not be
+carried into an image (AMI) built from this instance.
+
+This removes leftover OS state files, such as the network interface configuration
+cache (NetworkInterfaces.plist), required when creating & after provisioning
+derived images from an instance.
+
+This command requires root privileges. Run with sudo if not running as root.
+        `),
+		PreRunE: assertRootPrivileges,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			logrus.Info("Starting system state cleanup")
+
+			if err := system.NewStateCleaner(dryRun).Cleanup(cmd.Context()); err != nil {
+				logrus.WithError(err).Error("System state cleanup failed")
+				return err
+			}
+
+			logrus.Info("System state cleanup complete")
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "run command without mutating changes")
+
+	return cmd
+}

--- a/internal/cmd/system.go
+++ b/internal/cmd/system.go
@@ -44,7 +44,13 @@ This command requires root privileges. Run with sudo if not running as root.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logrus.Info("Starting system state cleanup")
 
-			if err := system.NewStateCleaner(dryRun).Cleanup(cmd.Context()); err != nil {
+			cleaner, err := system.NewStateCleaner(dryRun)
+			if err != nil {
+				logrus.WithError(err).Error("Unable to load cleanup-state configuration")
+				return err
+			}
+
+			if err := cleaner.Cleanup(cmd.Context()); err != nil {
 				logrus.WithError(err).Error("System state cleanup failed")
 				return err
 			}

--- a/internal/system/cleanup-state.toml
+++ b/internal/system/cleanup-state.toml
@@ -1,0 +1,12 @@
+# Default OS state removed by `ec2-macos-utils system cleanup-state`.
+#
+# Each [[state]] entry is a path (relative to the system root) removed before
+# an instance is imaged. To customize, place a file with this schema at
+# /usr/local/aws/ec2-macos-utils/cleanup-state.toml; it replaces these
+# defaults entirely.
+
+[[state]]
+path        = "Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"
+description = "macOS cached interface configuration"
+rationale   = "affects startup health of networking for EC2 Mac instances"
+recursive   = false

--- a/internal/system/config.go
+++ b/internal/system/config.go
@@ -1,0 +1,48 @@
+package system
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+// defaultConfigPath is an optional external cleanup-state configuration. When
+// present it replaces the built-in default state list entirely.
+const defaultConfigPath = "/usr/local/aws/ec2-macos-utils/cleanup-state.toml"
+
+// defaultConfig is the built-in cleanup-state configuration used when no
+// external config is present.
+//
+//go:embed cleanup-state.toml
+var defaultConfig []byte
+
+// stateConfig is the on-disk schema for cleanup-state configuration.
+type stateConfig struct {
+	State []StateEntry `toml:"state"`
+}
+
+// loadStateEntries returns the state entries from the external config at path
+// if it exists, otherwise from the embedded default. A config that cannot be
+// read or parsed is an error so a broken config never silently skips cleanup.
+func loadStateEntries(path string) ([]StateEntry, error) {
+	data := defaultConfig
+	source := "embedded default config"
+
+	if b, err := os.ReadFile(path); err == nil {
+		data = b
+		source = path
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return nil, fmt.Errorf("read cleanup-state config %q: %w", path, err)
+	}
+
+	var cfg stateConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse cleanup-state config (%s): %w", source, err)
+	}
+
+	return cfg.State, nil
+}

--- a/internal/system/config_test.go
+++ b/internal/system/config_test.go
@@ -1,0 +1,58 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadStateEntries_EmbeddedDefault(t *testing.T) {
+	entries, err := loadStateEntries(filepath.Join(t.TempDir(), "absent.toml"))
+
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	assert.Equal(t, networkInterfacesPlist, entries[0].Path, "default should target the interface cache")
+}
+
+func TestLoadStateEntries_ExternalConfigReplacesDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cleanup-state.toml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+[[state]]
+path        = "Library/Caches/custom"
+description = "custom state"
+rationale   = "test"
+recursive   = true
+`), 0644))
+
+	entries, err := loadStateEntries(path)
+
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "external config should replace, not extend, the default")
+	assert.Equal(t, "Library/Caches/custom", entries[0].Path)
+	assert.True(t, entries[0].Recursive)
+}
+
+func TestLoadStateEntries_MalformedConfigErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cleanup-state.toml")
+	require.NoError(t, os.WriteFile(path, []byte("this = is = not = toml"), 0644))
+
+	_, err := loadStateEntries(path)
+
+	assert.Error(t, err, "a malformed config must be an error, not a silent fallback")
+}
+
+func TestLoadStateEntries_UnreadableConfigErrors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-based test cannot run as root")
+	}
+
+	path := filepath.Join(t.TempDir(), "cleanup-state.toml")
+	require.NoError(t, os.WriteFile(path, []byte("[[state]]\n"), 0000))
+
+	_, err := loadStateEntries(path)
+
+	assert.Error(t, err, "an unreadable config must be an error, not a silent fallback")
+}

--- a/internal/system/state.go
+++ b/internal/system/state.go
@@ -1,0 +1,123 @@
+package system
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/sirupsen/logrus"
+)
+
+// StateEntry describes a well-known piece of OS state that must be removed
+// from an instance before it is suitable for imaging (e.g. AMI creation).
+type StateEntry struct {
+	// Path is the path of the state relative to the target system root.
+	Path string
+	// Description is a short, human-readable name for the state.
+	Description string
+	// Rationale explains why the state must be removed.
+	Rationale string
+	// Recursive controls whether a directory and all of its contents are removed.
+	Recursive bool
+}
+
+// cleanupStateEntries is the set of well-known OS state that is removed
+// during state cleanup.
+var cleanupStateEntries = []StateEntry{
+	{
+		Path:        "Library/Preferences/SystemConfiguration/NetworkInterfaces.plist",
+		Description: "macOS cached interface configuration",
+		Rationale:   "affects startup health of networking for EC2 Mac instances",
+	},
+}
+
+// StateCleaner removes well-known OS state beneath a target system root.
+//
+// The target root is an internal abstraction to permit future use against
+// other targets (e.g. an external volume); commands always target the
+// running system's root.
+type StateCleaner struct {
+	// targetRoot is the root path of the system whose state is cleaned.
+	targetRoot string
+	// entries is the OS state removed by Cleanup.
+	entries []StateEntry
+	// dryRun reports cleanup actions without removing state.
+	dryRun bool
+}
+
+// NewStateCleaner returns a StateCleaner that cleans up the running system.
+func NewStateCleaner(dryRun bool) *StateCleaner {
+	return newStateCleaner("/", dryRun)
+}
+
+// newStateCleaner returns a StateCleaner that cleans up the system rooted at
+// the given target root.
+func newStateCleaner(targetRoot string, dryRun bool) *StateCleaner {
+	return &StateCleaner{
+		targetRoot: targetRoot,
+		entries:    slices.Clone(cleanupStateEntries),
+		dryRun:     dryRun,
+	}
+}
+
+// Cleanup removes each well-known OS state entry beneath the target root.
+// State that does not exist is skipped. Removal continues through errors so
+// each entry is attempted; any errors encountered are joined and returned.
+// A canceled context stops cleanup before the next entry is attempted.
+func (c *StateCleaner) Cleanup(ctx context.Context) error {
+	var errs []error
+
+	for _, entry := range c.entries {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, err)
+			break
+		}
+
+		if err := c.remove(entry); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// remove removes a single state entry beneath the target root, logging the
+// action taken. Absent state is not an error.
+func (c *StateCleaner) remove(entry StateEntry) error {
+	path := filepath.Join(c.targetRoot, entry.Path)
+
+	log := logrus.WithFields(logrus.Fields{
+		"path":  path,
+		"state": entry.Description,
+	})
+
+	if _, err := os.Lstat(path); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			log.Info("State not present, nothing to remove")
+			return nil
+		}
+		return fmt.Errorf("inspect %q: %w", path, err)
+	}
+
+	if c.dryRun {
+		log.Infof("Dry run: would remove state (%s: %s)", entry.Description, entry.Rationale)
+		return nil
+	}
+
+	var removeErr error
+	if entry.Recursive {
+		removeErr = os.RemoveAll(path)
+	} else {
+		removeErr = os.Remove(path)
+	}
+	if removeErr != nil {
+		return fmt.Errorf("remove %q: %w", path, removeErr)
+	}
+
+	log.Infof("Removed state (%s: %s)", entry.Description, entry.Rationale)
+	return nil
+}

--- a/internal/system/state.go
+++ b/internal/system/state.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"github.com/sirupsen/logrus"
 )
@@ -16,23 +15,13 @@ import (
 // from an instance before it is suitable for imaging (e.g. AMI creation).
 type StateEntry struct {
 	// Path is the path of the state relative to the target system root.
-	Path string
+	Path string `toml:"path"`
 	// Description is a short, human-readable name for the state.
-	Description string
+	Description string `toml:"description"`
 	// Rationale explains why the state must be removed.
-	Rationale string
+	Rationale string `toml:"rationale"`
 	// Recursive controls whether a directory and all of its contents are removed.
-	Recursive bool
-}
-
-// cleanupStateEntries is the set of well-known OS state that is removed
-// during state cleanup.
-var cleanupStateEntries = []StateEntry{
-	{
-		Path:        "Library/Preferences/SystemConfiguration/NetworkInterfaces.plist",
-		Description: "macOS cached interface configuration",
-		Rationale:   "affects startup health of networking for EC2 Mac instances",
-	},
+	Recursive bool `toml:"recursive"`
 }
 
 // StateCleaner removes well-known OS state beneath a target system root.
@@ -50,18 +39,26 @@ type StateCleaner struct {
 }
 
 // NewStateCleaner returns a StateCleaner that cleans up the running system.
-func NewStateCleaner(dryRun bool) *StateCleaner {
-	return newStateCleaner("/", dryRun)
+// State entries are loaded from the external config if present, otherwise
+// from the embedded default; a config that cannot be loaded is an error.
+func NewStateCleaner(dryRun bool) (*StateCleaner, error) {
+	return newStateCleaner("/", defaultConfigPath, dryRun)
 }
 
 // newStateCleaner returns a StateCleaner that cleans up the system rooted at
-// the given target root.
-func newStateCleaner(targetRoot string, dryRun bool) *StateCleaner {
+// the given target root, loading state entries from configPath (or the
+// embedded default when configPath is absent).
+func newStateCleaner(targetRoot string, configPath string, dryRun bool) (*StateCleaner, error) {
+	entries, err := loadStateEntries(configPath)
+	if err != nil {
+		return nil, err
+	}
+
 	return &StateCleaner{
 		targetRoot: targetRoot,
-		entries:    slices.Clone(cleanupStateEntries),
+		entries:    entries,
 		dryRun:     dryRun,
-	}
+	}, nil
 }
 
 // Cleanup removes each well-known OS state entry beneath the target root.

--- a/internal/system/state_test.go
+++ b/internal/system/state_test.go
@@ -29,12 +29,22 @@ func writeFile(t *testing.T, root string, relPath string) string {
 	return path
 }
 
+// newTestCleaner builds a cleaner that uses the embedded default config (no
+// external config path) rooted at root.
+func newTestCleaner(t *testing.T, root string, dryRun bool) *StateCleaner {
+	t.Helper()
+
+	cleaner, err := newStateCleaner(root, "", dryRun)
+	require.NoError(t, err)
+
+	return cleaner
+}
+
 func TestCleanup_RemovesKnownState(t *testing.T) {
 	root := t.TempDir()
 	path := writeFile(t, root, networkInterfacesPlist)
 
-	cleaner := newStateCleaner(root, false)
-	err := cleaner.Cleanup(context.Background())
+	err := newTestCleaner(t, root, false).Cleanup(context.Background())
 
 	assert.NoError(t, err)
 	assert.NoFileExists(t, path, "well-known state should be removed")
@@ -43,8 +53,7 @@ func TestCleanup_RemovesKnownState(t *testing.T) {
 func TestCleanup_AbsentStateIsNotError(t *testing.T) {
 	root := t.TempDir()
 
-	cleaner := newStateCleaner(root, false)
-	err := cleaner.Cleanup(context.Background())
+	err := newTestCleaner(t, root, false).Cleanup(context.Background())
 
 	assert.NoError(t, err, "cleanup should succeed when state is already absent")
 }
@@ -53,7 +62,7 @@ func TestCleanup_IsIdempotent(t *testing.T) {
 	root := t.TempDir()
 	writeFile(t, root, networkInterfacesPlist)
 
-	cleaner := newStateCleaner(root, false)
+	cleaner := newTestCleaner(t, root, false)
 
 	assert.NoError(t, cleaner.Cleanup(context.Background()))
 	assert.NoError(t, cleaner.Cleanup(context.Background()), "second cleanup should also succeed")
@@ -64,8 +73,7 @@ func TestCleanup_LeavesUnrelatedStateIntact(t *testing.T) {
 	writeFile(t, root, networkInterfacesPlist)
 	unrelated := writeFile(t, root, "Library/Preferences/SystemConfiguration/preferences.plist")
 
-	cleaner := newStateCleaner(root, false)
-	err := cleaner.Cleanup(context.Background())
+	err := newTestCleaner(t, root, false).Cleanup(context.Background())
 
 	assert.NoError(t, err)
 	assert.FileExists(t, unrelated, "unrelated state should not be removed")
@@ -75,8 +83,7 @@ func TestCleanup_DryRunLeavesStateIntact(t *testing.T) {
 	root := t.TempDir()
 	path := writeFile(t, root, networkInterfacesPlist)
 
-	cleaner := newStateCleaner(root, true)
-	err := cleaner.Cleanup(context.Background())
+	err := newTestCleaner(t, root, true).Cleanup(context.Background())
 
 	assert.NoError(t, err)
 	assert.FileExists(t, path, "dry-run should not remove well-known state")
@@ -91,7 +98,7 @@ func TestCleanup_RemovesSymlinkWithoutRemovingTarget(t *testing.T) {
 			require.NoError(t, os.MkdirAll(filepath.Dir(link), 0755))
 			require.NoError(t, os.Symlink(target, link))
 
-			cleaner := newStateCleaner(root, false)
+			cleaner := newTestCleaner(t, root, false)
 			cleaner.entries = []StateEntry{
 				{Path: networkInterfacesPlist, Description: "linked state", Recursive: recursive},
 			}
@@ -121,7 +128,7 @@ func TestCleanup_RecursiveControlsDirectoryRemoval(t *testing.T) {
 			const directory = "Library/Caches/test-state"
 			writeFile(t, root, filepath.Join(directory, "nested/state"))
 
-			cleaner := newStateCleaner(root, false)
+			cleaner := newTestCleaner(t, root, false)
 			cleaner.entries = []StateEntry{
 				{Path: directory, Description: "directory state", Recursive: tt.recursive},
 			}
@@ -146,8 +153,7 @@ func TestCleanup_CanceledContextLeavesStateIntact(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	cleaner := newStateCleaner(root, false)
-	err := cleaner.Cleanup(ctx)
+	err := newTestCleaner(t, root, false).Cleanup(ctx)
 
 	assert.ErrorIs(t, err, context.Canceled)
 	assert.FileExists(t, path, "canceled cleanup should not remove state")
@@ -168,7 +174,7 @@ func TestCleanup_ContinuesThroughErrors(t *testing.T) {
 	// Second entry should still be removed.
 	removable := writeFile(t, root, networkInterfacesPlist)
 
-	cleaner := newStateCleaner(root, false)
+	cleaner := newTestCleaner(t, root, false)
 	cleaner.entries = []StateEntry{
 		{Path: "blocked/state", Description: "blocked state"},
 		{Path: networkInterfacesPlist, Description: "removable state"},
@@ -181,20 +187,20 @@ func TestCleanup_ContinuesThroughErrors(t *testing.T) {
 }
 
 func TestNewStateCleaner_TargetsRunningSystem(t *testing.T) {
-	cleaner := NewStateCleaner(false)
+	cleaner, err := NewStateCleaner(false)
+	require.NoError(t, err)
 
 	assert.Equal(t, "/", cleaner.targetRoot)
 	assert.NotEmpty(t, cleaner.entries)
 	assert.False(t, cleaner.dryRun)
 }
 
-func TestNewStateCleaner_ClonesEntries(t *testing.T) {
-	first := newStateCleaner(t.TempDir(), false)
-	second := newStateCleaner(t.TempDir(), false)
-	originalPath := cleanupStateEntries[0].Path
+func TestNewStateCleaner_IndependentEntries(t *testing.T) {
+	first := newTestCleaner(t, t.TempDir(), false)
+	second := newTestCleaner(t, t.TempDir(), false)
 
+	original := second.entries[0].Path
 	first.entries[0].Path = "mutated"
 
-	assert.Equal(t, originalPath, cleanupStateEntries[0].Path, "cleaner should not mutate global entries")
-	assert.Equal(t, originalPath, second.entries[0].Path, "cleaners should not share entry storage")
+	assert.Equal(t, original, second.entries[0].Path, "cleaners should not share entry storage")
 }

--- a/internal/system/state_test.go
+++ b/internal/system/state_test.go
@@ -1,0 +1,200 @@
+package system
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	logrus.SetOutput(io.Discard)
+}
+
+const networkInterfacesPlist = "Library/Preferences/SystemConfiguration/NetworkInterfaces.plist"
+
+// writeFile creates a file (and its parent directories) beneath root.
+func writeFile(t *testing.T, root string, relPath string) string {
+	t.Helper()
+
+	path := filepath.Join(root, relPath)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+	require.NoError(t, os.WriteFile(path, []byte("test data"), 0644))
+
+	return path
+}
+
+func TestCleanup_RemovesKnownState(t *testing.T) {
+	root := t.TempDir()
+	path := writeFile(t, root, networkInterfacesPlist)
+
+	cleaner := newStateCleaner(root, false)
+	err := cleaner.Cleanup(context.Background())
+
+	assert.NoError(t, err)
+	assert.NoFileExists(t, path, "well-known state should be removed")
+}
+
+func TestCleanup_AbsentStateIsNotError(t *testing.T) {
+	root := t.TempDir()
+
+	cleaner := newStateCleaner(root, false)
+	err := cleaner.Cleanup(context.Background())
+
+	assert.NoError(t, err, "cleanup should succeed when state is already absent")
+}
+
+func TestCleanup_IsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, networkInterfacesPlist)
+
+	cleaner := newStateCleaner(root, false)
+
+	assert.NoError(t, cleaner.Cleanup(context.Background()))
+	assert.NoError(t, cleaner.Cleanup(context.Background()), "second cleanup should also succeed")
+}
+
+func TestCleanup_LeavesUnrelatedStateIntact(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, networkInterfacesPlist)
+	unrelated := writeFile(t, root, "Library/Preferences/SystemConfiguration/preferences.plist")
+
+	cleaner := newStateCleaner(root, false)
+	err := cleaner.Cleanup(context.Background())
+
+	assert.NoError(t, err)
+	assert.FileExists(t, unrelated, "unrelated state should not be removed")
+}
+
+func TestCleanup_DryRunLeavesStateIntact(t *testing.T) {
+	root := t.TempDir()
+	path := writeFile(t, root, networkInterfacesPlist)
+
+	cleaner := newStateCleaner(root, true)
+	err := cleaner.Cleanup(context.Background())
+
+	assert.NoError(t, err)
+	assert.FileExists(t, path, "dry-run should not remove well-known state")
+}
+
+func TestCleanup_RemovesSymlinkWithoutRemovingTarget(t *testing.T) {
+	for _, recursive := range []bool{false, true} {
+		t.Run(map[bool]string{false: "non-recursive", true: "recursive"}[recursive], func(t *testing.T) {
+			root := t.TempDir()
+			target := writeFile(t, root, "target/state")
+			link := filepath.Join(root, networkInterfacesPlist)
+			require.NoError(t, os.MkdirAll(filepath.Dir(link), 0755))
+			require.NoError(t, os.Symlink(target, link))
+
+			cleaner := newStateCleaner(root, false)
+			cleaner.entries = []StateEntry{
+				{Path: networkInterfacesPlist, Description: "linked state", Recursive: recursive},
+			}
+
+			err := cleaner.Cleanup(context.Background())
+
+			assert.NoError(t, err)
+			assert.NoFileExists(t, link, "cleanup should remove the symlink")
+			assert.FileExists(t, target, "cleanup should not remove a symlink's target")
+		})
+	}
+}
+
+func TestCleanup_RecursiveControlsDirectoryRemoval(t *testing.T) {
+	tests := []struct {
+		name      string
+		recursive bool
+		wantError bool
+	}{
+		{name: "non-recursive", recursive: false, wantError: true},
+		{name: "recursive", recursive: true, wantError: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			const directory = "Library/Caches/test-state"
+			writeFile(t, root, filepath.Join(directory, "nested/state"))
+
+			cleaner := newStateCleaner(root, false)
+			cleaner.entries = []StateEntry{
+				{Path: directory, Description: "directory state", Recursive: tt.recursive},
+			}
+
+			err := cleaner.Cleanup(context.Background())
+
+			if tt.wantError {
+				assert.Error(t, err, "non-recursive cleanup should reject a non-empty directory")
+				assert.DirExists(t, filepath.Join(root, directory))
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NoDirExists(t, filepath.Join(root, directory), "recursive cleanup should remove the directory tree")
+		})
+	}
+}
+
+func TestCleanup_CanceledContextLeavesStateIntact(t *testing.T) {
+	root := t.TempDir()
+	path := writeFile(t, root, networkInterfacesPlist)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cleaner := newStateCleaner(root, false)
+	err := cleaner.Cleanup(ctx)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.FileExists(t, path, "canceled cleanup should not remove state")
+}
+
+func TestCleanup_ContinuesThroughErrors(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission-based test cannot run as root")
+	}
+
+	root := t.TempDir()
+
+	// First entry's removal fails: its parent directory is read-only.
+	blocked := writeFile(t, root, "blocked/state")
+	require.NoError(t, os.Chmod(filepath.Dir(blocked), 0555))
+	t.Cleanup(func() { _ = os.Chmod(filepath.Dir(blocked), 0755) })
+
+	// Second entry should still be removed.
+	removable := writeFile(t, root, networkInterfacesPlist)
+
+	cleaner := newStateCleaner(root, false)
+	cleaner.entries = []StateEntry{
+		{Path: "blocked/state", Description: "blocked state"},
+		{Path: networkInterfacesPlist, Description: "removable state"},
+	}
+
+	err := cleaner.Cleanup(context.Background())
+
+	assert.Error(t, err, "blocked removal should be reported")
+	assert.NoFileExists(t, removable, "cleanup should continue past a failed entry")
+}
+
+func TestNewStateCleaner_TargetsRunningSystem(t *testing.T) {
+	cleaner := NewStateCleaner(false)
+
+	assert.Equal(t, "/", cleaner.targetRoot)
+	assert.NotEmpty(t, cleaner.entries)
+	assert.False(t, cleaner.dryRun)
+}
+
+func TestNewStateCleaner_ClonesEntries(t *testing.T) {
+	first := newStateCleaner(t.TempDir(), false)
+	second := newStateCleaner(t.TempDir(), false)
+	originalPath := cleanupStateEntries[0].Path
+
+	first.entries[0].Path = "mutated"
+
+	assert.Equal(t, originalPath, cleanupStateEntries[0].Path, "cleaner should not mutate global entries")
+	assert.Equal(t, originalPath, second.entries[0].Path, "cleaners should not share entry storage")
+}


### PR DESCRIPTION
## Summary

Adds `ec2-macos-utils system cleanup-state`, which removes well-known macOS state from the running system that must not be carried into an image (AMI) built from an instance. Initially this removes the macOS cached network interface configuration (`/Library/Preferences/SystemConfiguration/NetworkInterfaces.plist`), which affects startup health of networking on EC2 Mac instances launched from derived images.

- New `system` subcommand group for system provisioning & helper utilities.
- `cleanup-state` removes each well-known state entry beneath the system root; absent state is skipped, removal continues through errors and reports them all, and a `--dry-run` flag reports actions without removing anything. Requires root.
- The cleanup targets the running system only; the target root is an internal abstraction to permit future targets (e.g. external volumes) and is intentionally not exposed as a flag.
- Unit tests for the state cleaner (removal, recursion, dry run, error joining, cancellation, and cleaner isolation).
- Generated command docs.

This supports `ec2-macos-init clean` delegating OS-level cleanup to ec2-macos-utils by default (companion PR in aws/ec2-macos-init).

## Testing

- Builds darwin/amd64 + arm64; `go vet` clean; all unit tests pass.
- Validated end to end on mac1.metal (x86_64, macOS 15.7.7) and mac2.metal (arm64, macOS 26.3.1): removal, idempotence, dry run, plist regeneration on reboot with healthy networking, and integration with `ec2-macos-init clean`.